### PR TITLE
fix(testing): remove testDirectory option

### DIFF
--- a/docs/api-builders/jest.md
+++ b/docs/api-builders/jest.md
@@ -90,12 +90,6 @@ Type: `boolean`
 
 Prevent tests from printing messages through the console. (https://jestjs.io/docs/en/cli#silent)
 
-### testDirectory
-
-Type: `string`
-
-The path to the file to test. Only works when `testFile` is also specified.
-
 ### testFile
 
 Type: `string`

--- a/packages/builders/src/jest/jest.builder.spec.ts
+++ b/packages/builders/src/jest/jest.builder.spec.ts
@@ -1,5 +1,6 @@
 import JestBuilder from './jest.builder';
 import { normalize } from '@angular-devkit/core';
+import { TestLogger } from '@angular-devkit/architect/testing';
 jest.mock('jest');
 const { runCLI } = require('jest');
 import * as path from 'path';
@@ -8,7 +9,14 @@ describe('Jest Builder', () => {
   let builder: JestBuilder;
 
   beforeEach(() => {
-    builder = new JestBuilder();
+    builder = new JestBuilder({
+      host: <any>{},
+      logger: new TestLogger('test'),
+      workspace: <any>{
+        root: '/root'
+      },
+      architect: <any>{}
+    });
     runCLI.mockReturnValue(
       Promise.resolve({
         results: {
@@ -36,10 +44,7 @@ describe('Jest Builder', () => {
       {
         globals: JSON.stringify({
           'ts-jest': {
-            tsConfig: path.join(
-              '<rootDir>',
-              path.relative(root, './tsconfig.test.json')
-            ),
+            tsConfig: '/root/tsconfig.test.json',
             stringifyContentPathRegex: '\\.html$',
             astTransformers: [
               'jest-preset-angular/InlineHtmlStripStylesTransformer'
@@ -48,14 +53,12 @@ describe('Jest Builder', () => {
         }),
         watch: false
       },
-      ['./jest.config.js']
+      ['/root/jest.config.js']
     );
   });
 
   it('should send appropriate options to jestCLI when testFile and testDirectory are specified', () => {
     const root = normalize('/root');
-
-    jest.spyOn(builder as any, '_isInFolder').mockImplementation(() => true);
 
     builder
       .run({
@@ -64,7 +67,6 @@ describe('Jest Builder', () => {
         projectType: 'application',
         options: {
           testFile: 'lib.spec.ts',
-          testDirectory: 'shared/util',
           jestConfig: './jest.config.js',
           tsConfig: './tsconfig.test.json',
           codeCoverage: false,
@@ -79,10 +81,7 @@ describe('Jest Builder', () => {
         _: ['lib.spec.ts'],
         globals: JSON.stringify({
           'ts-jest': {
-            tsConfig: path.join(
-              '<rootDir>',
-              path.relative(root, './tsconfig.test.json')
-            ),
+            tsConfig: '/root/tsconfig.test.json',
             stringifyContentPathRegex: '\\.html$',
             astTransformers: [
               'jest-preset-angular/InlineHtmlStripStylesTransformer'
@@ -94,7 +93,7 @@ describe('Jest Builder', () => {
         testNamePattern: 'should load',
         watch: false
       },
-      ['./jest.config.js']
+      ['/root/jest.config.js']
     );
   });
 
@@ -130,10 +129,7 @@ describe('Jest Builder', () => {
       {
         globals: JSON.stringify({
           'ts-jest': {
-            tsConfig: path.join(
-              '<rootDir>',
-              path.relative(root, './tsconfig.test.json')
-            ),
+            tsConfig: '/root/tsconfig.test.json',
             stringifyContentPathRegex: '\\.html$',
             astTransformers: [
               'jest-preset-angular/InlineHtmlStripStylesTransformer'
@@ -156,7 +152,7 @@ describe('Jest Builder', () => {
         watch: true,
         watchAll: false
       },
-      ['./jest.config.js']
+      ['/root/jest.config.js']
     );
   });
 
@@ -179,10 +175,7 @@ describe('Jest Builder', () => {
       {
         globals: JSON.stringify({
           'ts-jest': {
-            tsConfig: path.join(
-              '<rootDir>',
-              path.relative(root, './tsconfig.test.json')
-            ),
+            tsConfig: '/root/tsconfig.test.json',
             stringifyContentPathRegex: '\\.html$',
             astTransformers: [
               'jest-preset-angular/InlineHtmlStripStylesTransformer'
@@ -194,7 +187,7 @@ describe('Jest Builder', () => {
         ],
         watch: false
       },
-      ['./jest.config.js']
+      ['/root/jest.config.js']
     );
   });
 

--- a/packages/builders/src/jest/schema.json
+++ b/packages/builders/src/jest/schema.json
@@ -11,10 +11,6 @@
       "description": "The path of the Jest configuration. (https://jestjs.io/docs/en/configuration)",
       "type": "string"
     },
-    "testDirectory": {
-      "description": "The path to the file to test. Only works when `testFile` is also specified.",
-      "type": "string"
-    },
     "testFile": {
       "description": "The name of the file to test. Might work alone or in conjunction with `testDirectory`.",
       "type": "string"


### PR DESCRIPTION
Thank you for all your work. Sorry this process is taking longer than you expected. Here's a commit which would remove `testDirectory` option but still allow debugging to work.

## Current Behavior (This is the behavior we have today, before the PR is merged)

`testDirectory` is unnecessary and is a false negative when used outside of VSCode

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

You can use the VSCode Jest extension without `testDirectory` and it's removed with the following config

```
{
  // Use IntelliSense to learn about possible attributes.
  // Hover to view descriptions of existing attributes.
  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
  "version": "0.2.0",
  "configurations": [
    {
      "type": "node",
      "name": "vscode-jest-tests",
      "request": "launch",
      "args": [
        "test",
        "--passWithNoTests",
        "--no-code-coverage",
        "--runInBand",
        "--testFile"
      ],
      "cwd": "${fileDirname}",
      "console": "integratedTerminal",
      "internalConsoleOptions": "neverOpen",
      "program": "${workspaceFolder}/node_modules/@angular/cli/bin/ng"
    }
  ]
}
```

## Issue
